### PR TITLE
Workaround_for_CVE-2020-16898.ps1

### DIFF
--- a/Workaround_for_CVE-2020-16898.ps1
+++ b/Workaround_for_CVE-2020-16898.ps1
@@ -1,0 +1,66 @@
+# Evaluation code
+
+#define osversion number
+$osversion = (get-itemproperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name ReleaseId).ReleaseId
+
+#define KB Number and check for presence
+
+$1709 = 'KB4580328'
+$1803 = 'KB4580330'
+$1809 = 'KB4577668'
+$1903 = 'KB4577671'
+$2004 = 'KB4579311'
+
+#Check applicable OS version and installation of patch
+
+if ($osversion -eq '1709'){ 
+	$patched1 = Get-Hotfix -Id $1709 -ErrorAction SilentlyContinue
+}
+elseif ($osversion -eq '1803'){ 
+	$patched2 = Get-Hotfix -Id $1803 -ErrorAction SilentlyContinue
+}
+elseif ($osversion -eq '1809'){ 
+	$patched3 = Get-Hotfix -Id $1809 -ErrorAction SilentlyContinue
+}
+elseif ($osversion -eq '1903'){ 
+	$patched4 = Get-Hotfix -Id $1903 -ErrorAction SilentlyContinue
+}
+elseif ($osversion -eq '2004'){ 
+	$patched5 = Get-Hotfix -Id $2004 -ErrorAction SilentlyContinue
+}
+
+#if KB is not installed continue to check if workaround is applied
+if ($? -eq "True")
+{Write-Output "patch installed"
+exit 0}
+else {
+Write-Output "patch not installed"
+}
+
+#define interface numbers
+$INTERFACENUMBER=(Get-NetIPInterface -AddressFamily IPv6).ifIndex
+
+#determine if workaround has already been applied if already applied exit 0
+Foreach ($interface in $INTERFACENUMBER)
+{
+$output = (netsh int ipv6 show int "$interface")[-3]
+if ($output -eq 'RA Based DNS Config (RFC 6106)     : enabled'){
+Write-Output "Workaround required"}
+else {
+exit 0 
+}
+}
+
+# Remediation Code
+
+$INTERFACENUMBER=(Get-NetIPInterface -AddressFamily IPv6).ifIndex
+Foreach ($interface in $INTERFACENUMBER)
+{
+$output = netsh int ipv6 set int $interface rabaseddnsconfig=disable 
+if ($output -eq 'Ok.'){Write-Output "Workaround aplied on ifindex $interface"
+}
+else {Write-Output "something went wrong" 
+}
+}
+
+


### PR DESCRIPTION
In this worklet we check if a host is possibly vulnerable for CVE-2020-16898 based on the OS version and the installation status of the patch. If the patch is not installed the workaround is implemented.

For more info check: https://portal.msrc.microsoft.com/en-us/security-guidance/advisory/CVE-2020-16898#ID0EUGAC 3

The only manual task is to later revert this change when the patch is applied.